### PR TITLE
Fixed some filename typos to fix compiling on case-sensitive filesystems

### DIFF
--- a/sequencer_app_v2/src/Buttons.h
+++ b/sequencer_app_v2/src/Buttons.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "Display.h"
-#include "AnalogIo.h"
+#include "AnalogIO.h"
 #include <MCP23S17.h>
 
 namespace supersixteen{

--- a/sequencer_app_v2/src/Main.h
+++ b/sequencer_app_v2/src/Main.h
@@ -4,7 +4,7 @@
 #define _MAIN_h
 
 #if defined(ARDUINO) && ARDUINO >= 100
-	#include "arduino.h"
+	#include "Arduino.h"
 #else
 	#include "WProgram.h"
 #endif


### PR DESCRIPTION
There are 2 typos with small letters in place of capital ones in include statements, causing compilation to fail on case-sensitive filesystems like ext4. This PR fixes those and allows the firmware to be built on GNU/Linux.